### PR TITLE
index: add missing export for milestone-generator

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
 'use strict';
 
 exports.IssueFinder = require('./lib/issue-finder');
+
+exports.milestoneGenerator = require('./lib/milestone-generator');

--- a/test/test-issue-finder.js
+++ b/test/test-issue-finder.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var IssueFinder = require('../lib/issue-finder');
+var IssueFinder = require('../index').IssueFinder;
 var Octokat = require('./fixtures/fake-octokat');
 var tap = require('tap');
 

--- a/test/test-milestone-generator.js
+++ b/test/test-milestone-generator.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Octokat = require('./fixtures/fake-octokat');
-var milestoneGenerator = require('../lib/milestone-generator');
+var milestoneGenerator = require('../index').milestoneGenerator;
 var tap = require('tap');
 
 tap.test('milestone-generator', function(t) {


### PR DESCRIPTION
Add missing export to index and change tests to use index exports (as a rule, to prevent this in future)