### PR TITLE
milestone-generator: switch to /users route

### DIFF
--- a/lib/milestone-generator.js
+++ b/lib/milestone-generator.js
@@ -4,10 +4,10 @@ var Promise = require('bluebird');
 var assert = require('assert');
 var debug = require('./debug')('milestone-generator');
 var fmt = require('util').format;
-var inspect = require('util').inspect;
 var util = require('./util');
 
 module.exports = function(options) {
+  options.console = options.verbose ? console.log : debug;
   assert(options.octo, 'missing octo property');
   assert(options.org || options.user, 'missing org or user property');
   assert(options.title, 'missing title property');
@@ -18,29 +18,28 @@ module.exports = function(options) {
 
   if (options.org) {
     debug('searching by org');
-    return createMilestone(octo.orgs(options.org).repos, options);
+    return createMilestone(octo.orgs(options.org).repos, null, options);
   } else {
-    debug('searching by user');
-    return createMilestone(octo.users(options.user).repos, options);
+    debug('searching repos owned by user');
+    return createMilestone(octo.user.repos, { affiliation: 'owner' }, options);
   }
 };
 
-function createMilestone(repos, options) {
-  debug('repos: %s', inspect(repos));
-  return util.getAllPages(repos.fetch).then(function(repos) {
+function createMilestone(fn, filter, options) {
+  return util.getAllPages(fn.fetch, filter).then(function(repos) {
     return Promise.map(repos, function(repo) {
-      var msg = fmt('creating milestone for repo %s', repo.name);
-      if (options.verbose) {
-        console.log(msg);
+      if (!options.dryrun) {
+        return repo.milestones.create({
+          title: options.title,
+          description: options.description,
+          due_on: options.due_on,
+          state: 'open',
+        }).then(function() {
+          return fmt('created milestone for repo %s', repo.name);
+        });
       } else {
-        debug(msg);
+        return fmt('dry run: milestone for repo %s', repo.name);
       }
-      return repo.milestones.create({
-        title: options.title,
-        description: options.description,
-        due_on: options.due_on,
-        state: 'open',
-      });
     });
   });
 

--- a/test/fixtures/fake-octokat.js
+++ b/test/fixtures/fake-octokat.js
@@ -76,6 +76,10 @@ function Octokat() {
     fakeRepo,
   ];
 
+  this.user = {
+    repos: this.repos(),
+  };
+
   // Octokat API will sometimes return array or an iterable object;
   // this fake needs to simulate both behaviours.
   this.repoInfo.issues = fakeRepo.issues;
@@ -87,9 +91,6 @@ Octokat.prototype.orgs = function() {
     repos: self.repos(),
   };
 };
-
-// For the purposes of the fake, it's the same thing.
-Octokat.prototype.users = Octokat.prototype.orgs;
 
 Octokat.prototype.repos = function() {
   var self = this;


### PR DESCRIPTION
Switching from /user/:username/repos to /user/repos to allow
retrieval of private repositories. User-based retrieval will only
retrieve repositories owned by that user.