### PR TITLE
milestone-generator: allow individual failures

### DIFF
--- a/lib/milestone-generator.js
+++ b/lib/milestone-generator.js
@@ -25,8 +25,13 @@ module.exports = function(options) {
         return Promise.reject(list.error);
       }
       return Promise.map(list.repos, function(repo) {
-        return octo.repos(repo.org, repo.name).fetch().then(function(repo) {
-          return createMilestone(repo, options);
+        return Promise.try(function() {
+          return octo.repos(repo.org, repo.name).fetch().then(function(repo) {
+            return createMilestone(repo, options);
+          });
+        }).catch(function(err) {
+          return fmt('unable to create milestone for %s/%s: %s', repo.org,
+            repo.name, err.message);
         });
       });
     });


### PR DESCRIPTION
Individual repo failures should not prevent the remainder of the
list entries from having their milestones created.